### PR TITLE
fix: set the value of readableHighWaterMark when undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,9 @@ function ReadStream(input, options) {
 
   Readable.call(this, options);
 
+  if (this.readableHighWaterMark === undefined)
+      this.readableHighWaterMark = options.highWaterMark
+
   this.input = Buffer.from(input || '', options.encoding || 'utf8');
   // fake current file position
   this.input._position = 0;


### PR DESCRIPTION
In order to support node less than v9.3.0

> readable.readableHighWaterMark#
> Added in: v9.3.0